### PR TITLE
feat: only unset global flags if user is on campus

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,16 @@ https://gist.github.com/{username}/{git-gist-id}/raw/
 In your terminal, run
 
 ```sh
+# on-campus computer
+git-iam --init https://gist.github.com/{username}/{git-gist-id}/raw/ --on-campus
+
+# online student computer
 git-iam --init https://gist.github.com/{username}/{git-gist-id}/raw/
 ```
 
 **Replace the link after the `--init` with your Git Gist link**
+
+**Note:** `--on-campus` should be used when setting up on a shared computer (this will clear the global git config when users use `git iam <name>`)
 
 This command
 
@@ -84,8 +90,13 @@ git iam jane
 and it will have the same effect as running:
 
 ```sh
+# if initialized with --on-campus only
+------
 git config --global --unset-all user.name
 git config --global --unset-all user.email
+------
+
+# always run
 git config user.name "Jane Dev"
 git config user.email "jane.dev@github.email.com"
 ```

--- a/bin/index.js
+++ b/bin/index.js
@@ -3,56 +3,79 @@
 const shell = require('shelljs')
 const request = require('superagent')
 
-const alias = process.argv[2].toLowerCase()
+const alias = process.argv[2]?.toLowerCase()
 const listingUrl = process.argv[3]
 
 if (!alias) {
   showUsage()
 } else if (alias === '--init') {
-  setupExtension(listingUrl)
+  const isOnCampus = process.argv[4] === '--on-campus'
+  setupExtension(listingUrl, isOnCampus)
 } else {
   configureUser(alias)
 }
 
-function showUsage () {
+function showUsage() {
   console.info(`Usage:
-  git-iam --init url
-    Sets up the extension. The url should be the address of a JSON file.
+  git-iam --init url [--on-campus]
+    Sets up the extension. The url should be the address of a JSON file. Pass the --on-campus flag if you are on campus.
   git iam user
     Sets the name and email config of the user based on the JSON file.`)
 }
 
-function setupExtension (url) {
+function setupExtension(url, isOnCampus) {
   if (!url) return showUsage()
+
   shell.exec('git config --global users.url ' + url)
   shell.exec('git config --global alias.iam !git-iam')
+
+  if (isOnCampus) {
+    shell.exec('git config --global user.on-campus true')
+  }
+
   console.info('URL saved - initialization complete')
 }
 
-async function configureUser (alias) {
+async function configureUser(alias) {
   const url = getUrl()
-  const name = alias.replace(/\b\w/g, l => l.toUpperCase()) // capitalise
+  const name = alias.replace(/\b\w/g, (l) => l.toUpperCase()) // capitalise
   const users = await getUserListing(url)
   const user = users && users[alias]
+
   if (!user) {
     const errMsg = `Error: user "${alias}" is not defined in ${url}`
     return console.error(errMsg)
   }
-  shell.exec('git config --global --unset-all user.name')
-  shell.exec('git config --global --unset-all user.email')
+
+  if (isOnCampus()) {
+    shell.exec('git config --global --unset-all user.name')
+    shell.exec('git config --global --unset-all user.email')
+  }
+
   shell.exec(`git config --replace-all user.name "${user.name}"`)
   shell.exec(`git config --replace-all user.email "${user.email}"`)
   console.info(`Hiya ${name}, the future commits in this repo will be yours.`)
 }
 
-function getUrl () {
-  return shell.exec('git config --list', {silent: true})
+function getUrl() {
+  return shell
+    .exec('git config --list', { silent: true })
     .stdout.split('\n')
-    .find(i => i.includes('users.url'))
+    .find((i) => i.includes('users.url'))
     .split('=')[1]
 }
 
-async function getUserListing (url) {
+function isOnCampus() {
+  const flag = shell
+    .exec('git config --list', { silent: true })
+    .stdout.split('\n')
+    .find((line) => line.includes('user.on-campus'))
+    ?.split('=')[1]
+
+  return flag === 'true'
+}
+
+async function getUserListing(url) {
   try {
     const listing = await request.get(url)
     return JSON.parse(listing.text)
@@ -60,4 +83,3 @@ async function getUserListing (url) {
     return console.error(ex)
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-iam",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Git extension for setting name and email config quickly",
   "repository": "https://github.com/enspiral-dev-academy/git-iam",
   "author": "Don Smith <don@devacademy.co.nz>",


### PR DESCRIPTION
This changes the behaviour of how the git config is set up and it behaves when setting a user.

If the script is setup with the `--on-campus` flag, then using `git iam <name>` _will_ unset the global git user (which is necessary for on-campus cohorts). Otherwise it will not (which is helpful for online cohorts)

## Usage:

On-campus machine:
```sh
git-iam --init https://gist.githubusercontent.com/example-user/123example-id/raw/ --on-campus
```

Online students:
```sh
git-iam --init https://gist.githubusercontent.com/example-user/123example-id/raw/
```